### PR TITLE
lava-resources: automate release creation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,34 @@
+# Copyright 2023 Adevinta
+
+name: Release
+
+on:
+  push:
+    tags:
+      - '*/v[0-9]+.[0-9]+.[0-9]+*'
+
+permissions:
+  contents: write
+
+# Allow only one concurrent deployment, skipping runs queued between
+# the run in-progress and latest queued. However, do not cancel
+# in-progress runs as we want to allow these production deployments to
+# complete.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Release
+        run: go run release.go
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing
+
+**This project is in an early stage, we are not accepting external
+contributions yet.**
+
+## Workflow
+
+The recommended workflow is feature branching.
+That means that new features are developed in branches that are merged
+to main once they are tested, reviewed and considered stable.
+
+Small, short-lived and self-contained feature branches along with
+small pull requests are recommended.
+Feature flags are helpful to avoid having very long lived branches
+that can be sometimes hard to merge, depending on how quickly the main
+branch is updated.
+
+The main branch of this repository is protected.
+No one is allowed to push directly to main.
+
+## Commit messages
+
+Commit messages in this project follow a specific set of conventions,
+which we discuss in this section.
+
+```
+Header line: explain the commit in one line (use the imperative)
+
+Body of commit message is a few lines of text, explaining things
+in more detail, possibly giving some background about the issue
+being fixed, etc.
+
+The body of the commit message can be several paragraphs, and
+please do proper word-wrap and keep columns shorter than about
+74 characters or so. That way "git log" will show things
+nicely even when it's indented.
+
+Make sure you explain your solution and why you're doing what you're
+doing, as opposed to describing what you're doing. Reviewers and your
+future self can read the patch, but might not understand why a
+particular solution was implemented.
+```
+
+The header line of the commit must be prefixed by the primary affected
+component followed by colon.
+
+The body of the commit can be omitted if the header line describes the
+change well enough and the pull request message contains the missing
+details.
+
+## Pull requests
+
+Similarly to what happens with commit messages, pull requests follow a
+specific set of conventions.
+
+The title must explain the pull request in one line (use the
+imperative) and must be prefixed by the primary affected component
+followed by colon.
+
+The body of the pull request is a few lines of text, explaining things
+in more detail, possibly giving some background about the issue being
+fixed, etc.
+
+Make sure you explain your solution and why you're doing what you're
+doing, as opposed to describing what you're doing.
+Reviewers and your future self can read the patch, but might not
+understand why a particular solution was implemented.
+
+Pull requests must be in a "mergeable" state, pass all the automatic
+checks and receive at least +1 from the reviewers before being merged.
+
+When merging pull requests, using merge commits is mandatory.
+That means that the commit history of the pull request must be
+meaningful and clean.

--- a/DISCLAIMER
+++ b/DISCLAIMER
@@ -1,0 +1,6 @@
+Copyright (c) 2023 Adevinta
+
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Adevinta
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # Lava Resources
 
-Remote resources used by Lava.
+Remote resources used by [Lava][lava].
+
+Lava is an open source vulnerability scanner that makes it easy to run
+security checks in your local and CI/CD environments.
+
+## Contributing
+
+**This project is in an early stage, we are not accepting external
+contributions yet.**
+
+To contribute, please read the [contribution
+guidelines][contributing].
+
+
+[lava]: https://github.com/adevinta/lava
+[contributing]: /CONTRIBUTING.md

--- a/README.md
+++ b/README.md
@@ -5,6 +5,31 @@ Remote resources used by [Lava][lava].
 Lava is an open source vulnerability scanner that makes it easy to run
 security checks in your local and CI/CD environments.
 
+## Managing Resources
+
+This process is automated based on the following conventions:
+
+  - Resources are grouped in directories.
+  - All the resources in the same directory are versioned together.
+  - Releases are created based on tags with the format `dir/semver`.
+    Where `dir` is the directory containing the resources and `semver`
+    is a semantic version.
+
+To add new resources to the repository, follow these steps:
+
+ 1. If a new resource group is required, create a directory in the
+    root of the repository.
+    Otherwise, use an existing directory.
+    Then, add the new resources inside.
+ 2. Create a pull request with the new changes.
+ 3. Once the pull request is approved and merged, push a tag with the
+    format `dir/semver`.
+    Where `dir` is the directory where the new resources are located
+    and `semver` is a semantic version.
+
+Resources can be updated and deleted following the same process.
+For more details, run `go doc`.
+
 ## Contributing
 
 **This project is in an early stage, we are not accepting external

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module release
+
+go 1.21.4
+
+require golang.org/x/mod v0.14.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/mod v0.14.0 h1:dGoOF9QVLYng8IHTm7BAyWqCqSheQ5pYWGhzW00YJr0=
+golang.org/x/mod v0.14.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=

--- a/release.go
+++ b/release.go
@@ -1,0 +1,178 @@
+// Copyright 2023 Adevinta
+
+/*
+Release publishes a new GitHub release with a given set of files.
+
+It expects an environment variable with the name GITHUB_REF_NAME. The
+value of GITHUB_REF_NAME must be a git tag with the format
+"dir/semver" (e.g. checktypes/v1.2.3).
+
+For a given tag, it creates three releases:
+
+  - dir/vMAJOR
+  - dir/vMAJOR.MINOR
+  - dir/vMAJOR.MINOR.PATCH
+
+If the version in the tag name corresponds to a prerelease, only
+vMAJOR.MINOR.PATCH-PRERELEASE is created.
+
+The regular files in the directory specified in the tag are attached
+to all the releases.
+
+For instance, if the tag is checktypes/v1.2.3, the following releases
+will be created:
+
+  - checktypes/v1     (updated if it already exists)
+  - checktypes/v1.2   (updated if it already exists)
+  - checktypes/v1.2.3
+
+The files under the directory "checktypes" are attached to all of
+them.
+
+This release schema allows users to pin versions depending on their
+needs. In other words,
+
+  - v1.2.3  :=  ==v1.2.3
+  - v1.2    :=  >=v1.2.0, <v1.3.0
+  - v1      :=  >=v1.0.0, <v2.0.0
+  - v0.2.3  :=  ==v0.2.3
+  - v0.2    :=  >=v0.2.0, <v0.3.0
+  - v0      :=  >=v0.0.0, <v1.0.0
+*/
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+func main() {
+	log.SetFlags(0)
+
+	refName := os.Getenv("GITHUB_REF_NAME")
+	if refName == "" {
+		log.Fatalf("error: missing env var GITHUB_REF_NAME")
+	}
+
+	dir, version, err := parseRef(refName)
+	if err != nil {
+		log.Fatalf("error: parse ref: %v", err)
+	}
+
+	files, err := readDir(dir)
+	if err != nil {
+		log.Fatalf("error: list files: %v", err)
+	}
+
+	hash, err := gitHash(refName)
+	if err != nil {
+		log.Fatalf("error: get hash: %v", err)
+	}
+
+	// Do not create vMAJOR and vMAJOR.MINOR for pre-releases.
+	releases := []string{version}
+	if semver.Prerelease(version) == "" {
+		releases = append(releases, semver.Major(version), semver.MajorMinor(version))
+	}
+
+	for _, r := range releases {
+		tag := dir + "/" + r
+
+		// Do not update vMAJOR.MINOR.PATCH.
+		update := tag != refName
+
+		if err := ghRelease(tag, hash, update, files); err != nil {
+			log.Fatalf("error: create GitHub release %q: %v", tag, err)
+		}
+	}
+}
+
+// parseRef parses a reference name with the format "dir/semver" (e.g.
+// checktypes/v1.2.3). It returns the directory and version parts of
+// the reference. An error is returned if the reference does not match
+// the expected format or the version is not a valid semantic version.
+func parseRef(ref string) (dir, version string, err error) {
+	parts := strings.Split(ref, "/")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid tag name %q", ref)
+	}
+
+	dir = parts[0]
+	version = parts[1]
+
+	if !semver.IsValid(version) {
+		return "", "", fmt.Errorf("invalid version %q", version)
+	}
+
+	return dir, version, nil
+}
+
+// gitHash returns the hash corresponding to the specified reference
+// using "git show-ref".
+func gitHash(ref string) (string, error) {
+	hash, err := cmdOutput("git", "show-ref", "--hash", ref)
+	if err != nil {
+		return "", fmt.Errorf("git show-ref: %w", err)
+	}
+	return hash, nil
+}
+
+// ghRelease creates a GitHub release using "gh release". If update is
+// true, it first tries to delete any existing release with the same
+// tag.
+func ghRelease(tag, target string, update bool, files []string) error {
+	if update {
+		if _, err := cmdOutput("gh", "release", "delete", "--cleanup-tag", "--yes", tag); err != nil {
+			log.Printf("warn: could not delete release %q", tag)
+		}
+	}
+
+	args := []string{"release", "create", "--target", target, tag}
+	args = append(args, files...)
+	if _, err := cmdOutput("gh", args...); err != nil {
+		return fmt.Errorf("gh release create: %w", err)
+	}
+
+	return nil
+}
+
+// readDir returns the list of files in the provided directory. The
+// returned filenames are prefixed with dir.
+func readDir(dir string) ([]string, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read dir: %w", err)
+	}
+
+	var files []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			log.Printf("warn: skipping dir %q", entry.Name())
+			continue
+		}
+		files = append(files, filepath.Join(dir, entry.Name()))
+	}
+
+	return files, nil
+}
+
+// cmdOutput runs the specified command and returns its standard
+// output. The returned output is trimmed. In case of error, it
+// returns stderr along with the error.
+func cmdOutput(name string, arg ...string) (string, error) {
+	stderr := &bytes.Buffer{}
+	cmd := exec.Command(name, arg...)
+	cmd.Stderr = stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("cmd output: %w: %#q", err, stderr)
+	}
+	return strings.TrimSpace(string(out)), nil
+}


### PR DESCRIPTION
This PR automates the creation of new releases. It adds a command
called `release` that creates/updates GitHub releases based on the
tags pushed into the repository. It also adds a GitHub Actions
Workflow that runs `release` when a tag with a specific format is
pushed. The process is detailed in the README file of the repository
and as doc comments.

Furthermore, it adds the MIT license and disclaimer notice and the
contribution guidelines.