### PR TITLE
release: fix the order in which releases are created

### DIFF
--- a/release.go
+++ b/release.go
@@ -76,11 +76,14 @@ func main() {
 		log.Fatalf("error: get hash: %v", err)
 	}
 
+	var releases []string
+
 	// Do not create vMAJOR and vMAJOR.MINOR for pre-releases.
-	releases := []string{version}
 	if semver.Prerelease(version) == "" {
-		releases = append(releases, semver.Major(version), semver.MajorMinor(version))
+		releases = []string{semver.Major(version), semver.MajorMinor(version)}
 	}
+
+	releases = append(releases, version)
 
 	for _, r := range releases {
 		tag := dir + "/" + r

--- a/release.go
+++ b/release.go
@@ -49,6 +49,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"golang.org/x/mod/semver"
 )
@@ -135,6 +136,18 @@ func ghRelease(tag, target string, update bool, files []string) error {
 		if _, err := cmdOutput("gh", "release", "delete", "--cleanup-tag", "--yes", tag); err != nil {
 			log.Printf("warn: could not delete release %q", tag)
 		}
+
+		// BUG(rm): If a release is deleted and then created
+		// again to update its reference, the new release is
+		// created as draft. This happens because of a race
+		// condition on the GitHub side.
+		//
+		// A 30s delay should mitigate the issue while it is
+		// not fixed by GitHub.
+		//
+		// For more information, see
+		// https://github.com/cli/cli/issues/8458
+		time.Sleep(30 * time.Second)
 	}
 
 	args := []string{"release", "create", "--target", target, tag}


### PR DESCRIPTION
Fix the order in which releases are created, so `vMAJOR.MINOR.PATCH`
is marked as latest.